### PR TITLE
Fail when a forward migration lacks SQL

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ The word "last":
 		Run: Migrate,
 	}
 	cmdMigrate.Flags().StringVarP(&cliOptions.destinationVersion, "destination", "d", "last", "destination migration version")
-	cmdMigrate.Flags().BoolVarP(&cliOptions.noEmptyForward, "requirefoward", "r", false, "fail if forward step is devoid of SQL statements")
+	cmdMigrate.Flags().BoolVarP(&cliOptions.noEmptyForward, "requireforward", "r", false, "fail if forward step is devoid of SQL statements")
 	addConfigFlagsToCommand(cmdMigrate)
 
 	cmdStatus := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -89,7 +89,6 @@ type Config struct {
 
 var cliOptions struct {
 	destinationVersion string
-	noEmptyForward     bool
 	migrationsPath     string
 	configPath         string
 
@@ -204,7 +203,6 @@ The word "last":
 		Run: Migrate,
 	}
 	cmdMigrate.Flags().StringVarP(&cliOptions.destinationVersion, "destination", "d", "last", "destination migration version")
-	cmdMigrate.Flags().BoolVarP(&cliOptions.noEmptyForward, "requireforward", "r", false, "fail if forward step is devoid of SQL statements")
 	addConfigFlagsToCommand(cmdMigrate)
 
 	cmdStatus := &cobra.Command{
@@ -360,7 +358,7 @@ func Migrate(cmd *cobra.Command, args []string) {
 	}
 	defer conn.Close()
 
-	migrator, err := migrate.NewMigrator(conn, config.VersionTable, cliOptions.noEmptyForward)
+	migrator, err := migrate.NewMigrator(conn, config.VersionTable)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ type Config struct {
 
 var cliOptions struct {
 	destinationVersion string
+	noEmptyForward     bool
 	migrationsPath     string
 	configPath         string
 
@@ -203,6 +204,7 @@ The word "last":
 		Run: Migrate,
 	}
 	cmdMigrate.Flags().StringVarP(&cliOptions.destinationVersion, "destination", "d", "last", "destination migration version")
+	cmdMigrate.Flags().BoolVarP(&cliOptions.noEmptyForward, "requirefoward", "r", false, "fail if forward step is devoid of SQL statements")
 	addConfigFlagsToCommand(cmdMigrate)
 
 	cmdStatus := &cobra.Command{
@@ -358,7 +360,7 @@ func Migrate(cmd *cobra.Command, args []string) {
 	}
 	defer conn.Close()
 
-	migrator, err := migrate.NewMigrator(conn, config.VersionTable)
+	migrator, err := migrate.NewMigrator(conn, config.VersionTable, cliOptions.noEmptyForward)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 		os.Exit(1)

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -194,8 +194,9 @@ func (m *Migrator) LoadMigrations(path string) error {
 			containsSQL := false
 			for _, v := range strings.Split(upSQL, "\n") {
 				// Only account for regular single line comment.
-				if len(strings.TrimSpace(v)) != 0 &&
-					!strings.HasPrefix(v, "--") {
+				cleanString := strings.TrimSpace(v)
+				if len(cleanString) != 0 &&
+					!strings.HasPrefix(cleanString, "--") {
 					containsSQL = true
 					break
 				}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -17,6 +17,8 @@ import (
 
 var migrationPattern = regexp.MustCompile(`\A(\d+)_.+\.sql\z`)
 
+var ErrNoFwMigration = errors.Errorf("no sql in forward migration step")
+
 type BadVersionError string
 
 func (e BadVersionError) Error() string {
@@ -199,7 +201,7 @@ func (m *Migrator) LoadMigrations(path string) error {
 				}
 			}
 			if !containsSQL {
-				return errors.Errorf("no sql in forward migration step")
+				return ErrNoFwMigration
 			}
 		}
 		if len(pieces) == 2 {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -53,7 +53,7 @@ func (s *MigrateSuite) tableExists(c *C, tableName string) bool {
 
 func (s *MigrateSuite) createEmptyMigrator(c *C) *migrate.Migrator {
 	var err error
-	m, err := migrate.NewMigrator(s.conn, versionTable, false)
+	m, err := migrate.NewMigrator(s.conn, versionTable)
 	c.Assert(err, IsNil)
 	return m
 }
@@ -78,7 +78,7 @@ func (s *MigrateSuite) TestNewMigrator(c *C) {
 	var err error
 
 	// Initial run
-	m, err = migrate.NewMigrator(s.conn, versionTable, false)
+	m, err = migrate.NewMigrator(s.conn, versionTable)
 	c.Assert(err, IsNil)
 
 	// Creates version table
@@ -86,7 +86,7 @@ func (s *MigrateSuite) TestNewMigrator(c *C) {
 	c.Assert(schemaVersionExists, Equals, true)
 
 	// Succeeds when version table is already created
-	m, err = migrate.NewMigrator(s.conn, versionTable, false)
+	m, err = migrate.NewMigrator(s.conn, versionTable)
 	c.Assert(err, IsNil)
 
 	initialVersion, err := m.GetCurrentVersion()
@@ -160,7 +160,7 @@ func (s *MigrateSuite) TestLoadMigrations(c *C) {
 
 func (s *MigrateSuite) TestLoadMigrationsNoForward(c *C) {
 	var err error
-	m, err := migrate.NewMigrator(s.conn, versionTable, true)
+	m, err := migrate.NewMigrator(s.conn, versionTable)
 	c.Assert(err, IsNil)
 
 	m.Data = map[string]interface{}{"prefix": "foo"}
@@ -333,7 +333,7 @@ func Example_OnStartMigrationProgressLogging() {
 	}
 
 	var m *migrate.Migrator
-	m, err = migrate.NewMigrator(conn, "schema_version", false)
+	m, err = migrate.NewMigrator(conn, "schema_version")
 	if err != nil {
 		fmt.Printf("Unable to create migrator: %v", err)
 		return

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -165,7 +165,7 @@ func (s *MigrateSuite) TestLoadMigrationsNoForward(c *C) {
 
 	m.Data = map[string]interface{}{"prefix": "foo"}
 	err = m.LoadMigrations("testdata/noforward")
-	c.Assert(err, IsNil)
+	c.Assert(err, Equals, migrate.ErrNoFwMigration)
 }
 
 func (s *MigrateSuite) TestMigrate(c *C) {

--- a/migrate/testdata/noforward/001_create_no_forward.sql
+++ b/migrate/testdata/noforward/001_create_no_forward.sql
@@ -1,0 +1,4 @@
+
+---- create above / drop below ----
+
+drop table t1;

--- a/migrate/testdata/noforward/001_create_no_forward.sql
+++ b/migrate/testdata/noforward/001_create_no_forward.sql
@@ -1,3 +1,5 @@
+-- no SLQ here
+-- nor here, just all comments.
 
 ---- create above / drop below ----
 

--- a/migrate/testdata/noforward/001_create_no_forward.sql
+++ b/migrate/testdata/noforward/001_create_no_forward.sql
@@ -1,4 +1,4 @@
--- no SLQ here
+-- no SQL here
 -- nor here, just all comments.
  -- comment with space before
  

--- a/migrate/testdata/noforward/001_create_no_forward.sql
+++ b/migrate/testdata/noforward/001_create_no_forward.sql
@@ -1,6 +1,7 @@
 -- no SLQ here
 -- nor here, just all comments.
-
+ -- comment with space before
+ 
 ---- create above / drop below ----
 
 drop table t1;


### PR DESCRIPTION
Hey, I am not sure if this is something useful in general, we have found this to blow in our faces when we misplaced migration lines.

The idea is to be able to pass a flag on migration to have them blow in our faces if a forward step is suspiciously empty (Which we assume is not a very common use case)