### PR TITLE
Allow migrations to be split over multiple Conn.Exec calls

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -337,12 +337,14 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err erro
 		}
 
 		// Execute the migration
-		_, err = m.conn.Exec(ctx, sql)
-		if err != nil {
-			if err, ok := err.(*pgconn.PgError); ok {
-				return MigrationPgError{Sql: sql, PgError: err}
+		for _, stmt := range strings.Split(sql, "-- #SEND") {
+			_, err = m.conn.Exec(ctx, stmt)
+			if err != nil {
+				if err, ok := err.(*pgconn.PgError); ok {
+					return MigrationPgError{Sql: sql, PgError: err}
+				}
+				return err
 			}
-			return err
 		}
 
 		// Reset all database connection settings. Important to do before updating version as search_path may have been changed.


### PR DESCRIPTION
We found that postgres does not let you send certain commands with other commands. Example `create index concurrenrly`. Even if you disable tx this will bomb out if sent with a alter table statement. 

This PR allows migration writers to control how tern splits up migrations over multiple Exec calls. To do this you add a special sql comment. `-- #SEND` at the location you want to split before sending more sql. 