### PR TITLE
Allow migrations inside of a transaction

### DIFF
--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -315,6 +315,34 @@ func TestMigrateToIrreversible(t *testing.T) {
 	require.EqualError(t, err, "Irreversible migration: 1 - Foo")
 }
 
+func TestMigrateToDisableTxInTx(t *testing.T) {
+	conn := connectConn(t)
+	ctx := context.Background()
+	defer conn.Close(ctx)
+	tx, err := conn.Begin(ctx)
+	assert.NoError(t, err)
+
+	m, err := migrate.NewMigratorEx(ctx, conn, versionTable, &migrate.MigratorOptions{DisableTx: true})
+	assert.NoError(t, err)
+	m.AppendMigration("Create t1", "create table t1(id serial);", "drop table t1;")
+	m.AppendMigration("Create t2", "create table t2(id serial);", "drop table t2;")
+	m.AppendMigration("Create t3", "create table t3(id serial);", "drop table t3;")
+
+	err = m.MigrateTo(ctx, 3)
+	assert.NoError(t, err)
+	require.EqualValues(t, 3, currentVersion(t, conn))
+	require.True(t, tableExists(t, conn, "t1"))
+	require.True(t, tableExists(t, conn, "t2"))
+	require.True(t, tableExists(t, conn, "t3"))
+
+	err = tx.Rollback(ctx)
+	assert.NoError(t, err)
+	require.False(t, tableExists(t, conn, versionTable))
+	require.False(t, tableExists(t, conn, "t1"))
+	require.False(t, tableExists(t, conn, "t2"))
+	require.False(t, tableExists(t, conn, "t3"))
+}
+
 func TestMigrateToDisableTx(t *testing.T) {
 	conn := connectConn(t)
 	defer conn.Close(context.Background())


### PR DESCRIPTION
The way we run tests involves creating a transaction, running migrations, using save points during the test, then rolling back to leave the database empty again. This works really nicely except that if the version table does not exist yet, `migrate.NewMigratorEx` fails because the call to `Migrator.GetCurrentVersion` with a missing table aborts the transaction.

We currently work around this by duplicating `Migrator.ensureSchemaVersionTableExists` with this patch applied and calling that before `migrate.NewMigratorEx`.

This PR is in case you're interested in supporting this use case in tern itself. It replaces the method of checking for a missing version table with a query against the `pg_catalog.pg_tables` view. This leaves open transactions active, even if the version table does not exist.