### PR TITLE
offer default SSH keyfile if not using agent

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -280,7 +280,7 @@ your PostgreSQL server is `pg.example.com`, but you only have SSH access, then
 your SSH host would be pg.example.com and your database host would be
 `localhost`.
 
-Tern will automatically use an SSH agent if available.
+Tern will automatically use an SSH agent or `~/.ssh/id_rsa` if available.
 
 ## Embedding Tern
 


### PR DESCRIPTION
Running `tern` with `--ssh-host`/`--ssh-user` but no SSH agent would panic due to passing in a nil `ssh.AuthMethod`:
```
tern migrate --database xxx --user xxx --ssh-host xxx --ssh-user xxx --migrations xxx/xxx --destination x
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x83f215]
goroutine 1 [running]:
golang.org/x/crypto/ssh.(*connection).clientAuthenticate(0xc0000e6b00, 0xc0000b7ee0, 0x0, 0xa)
        /home/miles/go/pkg/mod/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83/ssh/client_auth.go:65 +0x435
golang.org/x/crypto/ssh.(*connection).clientHandshake(0xc0000e6b00, 0xc00002df88, 0x8, 0xc0000b7ee0, 0x0, 0x0)
        /home/miles/go/pkg/mod/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83/ssh/client.go:113 +0x2cf
golang.org/x/crypto/ssh.NewClientConn(0x9d34d8, 0xc000010140, 0xc00002df88, 0x8, 0xc0000fda10, 0x9d34d8, 0xc000010140, 0x0, 0x0, 0xc00002df88, ...)
        /home/miles/go/pkg/mod/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83/ssh/client.go:83 +0xf8
golang.org/x/crypto/ssh.Dial(0x938793, 0x3, 0xc00002df88, 0x8, 0xc0000fda10, 0x9384a9, 0x2, 0xc00002df88)
        /home/miles/go/pkg/mod/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83/ssh/client.go:177 +0xb8
main.NewSSHClient(0xc000001c28, 0xb, 0x0, 0x0)
        /data/tmp/miles/spack-stage-tern-1.12.4-lvq6fh4ydi7rft4mxgqeejqtd6c7xm4h/spack-src/ssh_tunnel.go:36 +0x20a
main.(*Config).Connect(0xc000001b00, 0x9d04b0, 0xc00002c0a8, 0x0, 0x1, 0x44f5ac)
        /data/tmp/miles/spack-stage-tern-1.12.4-lvq6fh4ydi7rft4mxgqeejqtd6c7xm4h/spack-src/main.go:135 +0x388
main.loadConfigAndConnectToDB(0x9d04b0, 0xc00002c0a8, 0xf, 0xf)
        /data/tmp/miles/spack-stage-tern-1.12.4-lvq6fh4ydi7rft4mxgqeejqtd6c7xm4h/spack-src/main.go:397 +0x19a
main.Migrate(0xc0000d2580, 0xc0000e03c0, 0x0, 0xc)
        /data/tmp/miles/spack-stage-tern-1.12.4-lvq6fh4ydi7rft4mxgqeejqtd6c7xm4h/spack-src/main.go:408 +0x77
github.com/spf13/cobra.(*Command).execute(0xc0000d2580, 0xc0000e0300, 0xc, 0xc, 0xc0000d2580, 0xc0000e0300)
        /home/miles/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d3b80, 0xc0000fdf70, 0x1, 0x1)
        /home/miles/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/miles/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
        /data/tmp/miles/spack-stage-tern-1.12.4-lvq6fh4ydi7rft4mxgqeejqtd6c7xm4h/spack-src/main.go:276 +0x89f
```
This PR fixes that and adds a fallback to `~/.ssh/id_rsa`.