### PR TITLE
update installation section for newer Go versions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,13 @@ workflow for managing database code such as functions and views.
 
 ## Installation
 
+Go versions up to and including 1.17:
+
     go get -u github.com/jackc/tern
+    
+Go versions 1.17 and higher:
+
+    go install github.com/jackc/tern@latest
 
 ## Creating a Tern Project
 


### PR DESCRIPTION
This change updates the README installation section, to use `go install` for newer Go versions (>= 1.17). Both the old `go get` method and new method remain described to support users of the older Go versions.

As of Go 1.17, the use of `go get` for installing executables is [deprecated]( https://golang.org/doc/go-get-install-deprecation). And will be disabled from Go 1.18. As per message on command line:

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
