### PR TITLE
add Filename to MigrationPgError

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -45,7 +45,8 @@ func (e NoMigrationsFoundError) Error() string {
 }
 
 type MigrationPgError struct {
-	Sql string
+	Filename string
+	Sql      string
 	*pgconn.PgError
 }
 
@@ -352,7 +353,7 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err erro
 		_, err = m.conn.Exec(ctx, sql)
 		if err != nil {
 			if err, ok := err.(*pgconn.PgError); ok {
-				return MigrationPgError{Sql: sql, PgError: err}
+				return MigrationPgError{Filename: current.Name, Sql: sql, PgError: err}
 			}
 			return err
 		}


### PR DESCRIPTION
Simply put, when using `tern/migrate` to run migrations, if a migration fails the error is returned and the PgError message is printed to the user. It would be useful to show to the user which of their migration files caused the error.

Intended use:

```go
if err := m.Migrate(ctx); err != nil {
  var migrationErr migrate.MigrationPgError
  if errors.As(err, &migrationErr) {
    fmt.Fprintf(os.Stderr, "failed to perform migration(s): %s: %v\n", migrationErr.Filename, migrationErr.PgError)
    os.Exit(1)  
  }
  // handle error
}
```