### PR TITLE
Implement embedded file system support (Go 1.16)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackc/tern
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Masterminds/goutils v1.1.0 // indirect

--- a/main.go
+++ b/main.go
@@ -512,7 +512,7 @@ func Migrate(cmd *cobra.Command, args []string) {
 			}
 
 			if mgErr.Position != 0 {
-				ele, err := ExtractErrorLine(mgErr.Sql, int(mgErr.Position))
+				ele, err := migrate.ExtractErrorLine(mgErr.Sql, int(mgErr.Position))
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
@@ -559,7 +559,7 @@ func InstallCode(cmd *cobra.Command, args []string) {
 			}
 
 			if err.Position != 0 {
-				ele, err := ExtractErrorLine(err.Sql, int(err.Position))
+				ele, err := migrate.ExtractErrorLine(err.Sql, int(err.Position))
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)

--- a/migrate/error_line_extract.go
+++ b/migrate/error_line_extract.go
@@ -1,4 +1,4 @@
-package main
+package migrate
 
 import (
 	"fmt"

--- a/migrate/error_line_extract_test.go
+++ b/migrate/error_line_extract_test.go
@@ -1,4 +1,4 @@
-package main
+package migrate
 
 import (
 	"testing"

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -99,14 +99,14 @@ func NewMigratorEx(ctx context.Context, conn *pgx.Conn, versionTable string, opt
 }
 
 type MigratorFS interface {
-	ReadDir(dirname string) ([]os.FileInfo, error)
+	ReadDir(dirname string) ([]fs.FileInfo, error)
 	ReadFile(filename string) ([]byte, error)
 	Glob(pattern string) (matches []string, err error)
 }
 
 type DefaultMigratorFS struct{}
 
-func (DefaultMigratorFS) ReadDir(dirname string) ([]os.FileInfo, error) {
+func (DefaultMigratorFS) ReadDir(dirname string) ([]fs.FileInfo, error) {
 	return ioutil.ReadDir(dirname)
 }
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -370,7 +370,10 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err erro
 		}
 
 		// Reset all database connection settings. Important to do before updating version as search_path may have been changed.
-		m.conn.Exec(ctx, "reset all")
+		_, err := m.conn.Exec(ctx, "reset all")
+		if err != nil {
+			return err
+		}
 
 		// Add one to the version
 		_, err = m.conn.Exec(ctx, "update "+m.versionTable+" set version=$1", sequence)


### PR DESCRIPTION
We need to embed tern into our app (container), so I implemented FS layer on top of embedded FS. The key change is to change os.FileInfo to fs.FileInfo which is more abstract and actually allows the code to work. On top of that, the PR also moves extract helper function from main package to the API package because that is very useful functionality to have. I also provide a small example on how to use that, added tests and changed a small error handling.

This bumps Go minimum version from 1.13 to 1.16. Now, if you do not like this, I can remove this change but I cannot provide unit test for the new functionality as embedding is a runtime feature that fails on 1.13. I can still provide the code so 1.16+ users can actually use the embedded FS type, but the code would be untested.

Cheers!