### PR TITLE
Change module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jackc/tern
+module github.com/jackc/tern/v2
 
 go 1.18
 


### PR DESCRIPTION
Hey,

appreciate the tag, however, it does not work due to missing module. Go errors with:

```
lzap@mone provisioning-backend % go mod tidy
go: downloading github.com/jackc/tern/v2 v2.0.0-beta.1
github.com/RHEnVision/provisioning-backend/internal/db imports
        github.com/jackc/tern/v2/migrate: go.mod has non-.../v2 module path "github.com/jackc/tern" (and .../v2/go.mod does not exist) at revision v2.0.0-beta.1
```