### PR TITLE
Fix data being overwriten during config merging

### DIFF
--- a/main.go
+++ b/main.go
@@ -876,7 +876,10 @@ func findMigrationsForRenumber(path string) ([]string, error) {
 }
 
 func LoadConfig() (*Config, error) {
-	config := &Config{VersionTable: "public.schema_version"}
+	config := &Config{
+		VersionTable: "public.schema_version",
+		Data:         make(map[string]interface{}),
+	}
 	if connConfig, err := pgx.ParseConfig(""); err == nil {
 		config.ConnConfig = *connConfig
 	} else {
@@ -1004,7 +1007,6 @@ func appendConfigFromFile(config *Config, path string) error {
 		config.SslRootCert = sslrootcert
 	}
 
-	config.Data = make(map[string]interface{})
 	for key, value := range file["data"] {
 		config.Data[key] = value
 	}


### PR DESCRIPTION
Sorry found a little bug with the config file merging. Since the data map was being initialized per config file it was being entirely overwritten instead of added to.