### PR TITLE
remove unnedded connection to db

### DIFF
--- a/main.go
+++ b/main.go
@@ -692,9 +692,11 @@ func SnapshotCode(cmd *cobra.Command, args []string) {
 }
 
 func PrintConnString(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	config, conn := loadConfigAndConnectToDB(ctx)
-	defer conn.Close(ctx)
+	config, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	connstring := config.ConnString
 	if connstring == "" {


### PR DESCRIPTION
I was accidentally using loadConfigAndConnectToDB instead of just LoadConfig. The connection is not needed for just printing out the connstring. oops. 