### PR TITLE
add dry run to tern

### DIFF
--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -233,6 +233,7 @@ func TestMigrateToLifeCycle(t *testing.T) {
 	var onStartCallUpCount int
 	var onStartCallDownCount int
 	m.OnStart = func(_ int32, _, direction, _ string) {
+		t.Log("OnStart", direction)
 		switch direction {
 		case "up":
 			onStartCallUpCount++

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -233,7 +233,6 @@ func TestMigrateToLifeCycle(t *testing.T) {
 	var onStartCallUpCount int
 	var onStartCallDownCount int
 	m.OnStart = func(_ int32, _, direction, _ string) {
-		t.Log("OnStart", direction)
 		switch direction {
 		case "up":
 			onStartCallUpCount++

--- a/tern_test.go
+++ b/tern_test.go
@@ -184,35 +184,40 @@ func TestMigrate(t *testing.T) {
 		expectedVersion   int32
 	}{
 		{[]string{"-d", "0"}, []string{}, []string{"t1", "t2"}, 0},
+		{[]string{"--dry-run"}, []string{}, []string{"t1", "t2"}, 0},
 		{[]string{}, []string{"t1", "t2"}, []string{}, 2},
 		{[]string{"-d", "1"}, []string{"t1"}, []string{"t2"}, 1},
 		{[]string{"-d", "-1"}, []string{}, []string{"t1", "t2"}, 0},
 		{[]string{"-d", "+1"}, []string{"t1"}, []string{"t2"}, 1},
 		{[]string{"-d", "+1"}, []string{"t1", "t2"}, []string{}, 2},
 		{[]string{"-d", "-+1"}, []string{"t1", "t2"}, []string{}, 2},
+		{[]string{"--dry-run"}, []string{}, []string{}, 2},
 	}
 
 	for i, tt := range tests {
-		baseArgs := []string{"migrate", "-m", "testdata", "-c", "testdata/tern.conf"}
-		args := append(baseArgs, tt.args...)
+		t.Run(fmt.Sprintf("args=%s", strings.Join(tt.args, " ")), func(t *testing.T) {
+			baseArgs := []string{"migrate", "-m", "testdata", "-c", "testdata/tern.conf"}
+			args := append(baseArgs, tt.args...)
 
-		tern(t, args...)
+			tern(t, args...)
 
-		for _, tableName := range tt.expectedExists {
-			if !tableExists(t, tableName) {
-				t.Fatalf("%d. Expected table %s to exist, but it doesn't", i, tableName)
+			for _, tableName := range tt.expectedExists {
+				if !tableExists(t, tableName) {
+					t.Fatalf("%d. Expected table %s to exist, but it doesn't", i, tableName)
+				}
 			}
-		}
 
-		for _, tableName := range tt.expectedNotExists {
-			if tableExists(t, tableName) {
-				t.Fatalf("%d. Expected table %s to not exist, but it does", i, tableName)
+			for _, tableName := range tt.expectedNotExists {
+				if tableExists(t, tableName) {
+					t.Fatalf("%d. Expected table %s to not exist, but it does", i, tableName)
+				}
 			}
-		}
 
-		if currentVersion(t) != tt.expectedVersion {
-			t.Fatalf(`Expected current version to be %d, but it was %d`, tt.expectedVersion, currentVersion(t))
-		}
+			if currentVersion(t) != tt.expectedVersion {
+				t.Fatalf(`Expected current version to be %d, but it was %d`, tt.expectedVersion, currentVersion(t))
+			}
+
+		})
 	}
 }
 


### PR DESCRIPTION
Adds a `--dry-run` feature to `tern`.

This is necessary in order to apply any templating logic necessary to output files, which can then be sent through any postgres linting tool if necessary.

As an example workflow, there's a pretty nice tool called [squawk](https://github.com/sbdchd/squawk) that outputs warnings on certain DDL changes, but arguably it could be any tool that requires valid Postgres DDL. These tools are becoming more and more popular leveraging the [lib_pg_query](https://github.com/pganalyze/libpg_query) so it's nice to be able to integrate with more static analysis.

```
❯ tern migrate -c dev.tern.conf -m ./migrations --dry-run | squawk
stdin:1:0: warning: prefer-bigint-over-int

   1 | -- file: 017_test.sql number: 17 - direction: up
   2 | CREATE TABLE test(foo INT);

  note: Hitting the max 32 bit integer is possible and may break your application.
  help: Use 64bit integer values instead to prevent hitting this limit.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
```

However, we use `tern` templated variables for some weirdness in dev/prod environments, so being able to run the migrations through tern (generating correct SQL), without executing them is a useful feature for static analysis.


Let me know if there's any feedback, off the top of my head some potentially contentious changes:
1. Changing `OnStart` function specifically for dry run - this means that all `tern` output is essentially type-safe SQL. I think it might be reasonable to use that for all specific output.
2. Still running `tx.Begin()` on `--dry-run`. I think the tests have it covered but am happy to also avoid creating any transaction if not necessary.


This is tested via all unit tests. Example of using on a local set up:
```
❯ tern migrate -c dev.tern.conf -m ./migrations --dry-run -d +1
-- file: 017_test.sql number: 17 - direction: up
CREATE TABLE test(foo INT);
```