### PR TITLE
Disable prepared statements when run from CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -1118,6 +1118,8 @@ func LoadConfig() (*Config, error) {
 		config.ConnConfig.RuntimeParams["application_name"] = "tern"
 	}
 
+	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeDescribeExec
+
 	return config, nil
 }
 


### PR DESCRIPTION
Apparently, when run through a connection pooler, the prepared statements from one run may persist to the next run because the underlying connection is not closed and it retains the prepared statements. This would cause the next run to fail because the prepared statement names are deterministic and would conflict with the already existing prepared statements.

https://github.com/jackc/tern/issues/100