### PR TITLE
Enhance ssh agent support (windows pipe and other id_* key files)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -95,6 +95,10 @@ password = {{env "MIGRATOR_PASSWORD"}}
 # user =
 # password is not required if using SSH agent authentication
 # password =
+# keyfile is the path to a SSH key file
+# keyfile = 
+# passphrase for the SSH key file given above or one of the default SSH key files in ~/.ssh
+# passphrase =
 
 [data]
 prefix = foo
@@ -353,7 +357,8 @@ your PostgreSQL server is `pg.example.com`, but you only have SSH access, then
 your SSH host would be pg.example.com and your database host would be
 `localhost`.
 
-Tern will automatically use an SSH agent or `~/.ssh/id_rsa` if available.
+Tern will automatically use an SSH agent or `~/.ssh/id_dsa`, `~/.ssh/id_rsa`, 
+`~/.ssh/ed25519` and`~/.ssh/id_ecdsa` if available.
 
 ## Embedding Tern
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.13
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
@@ -17,6 +18,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -111,10 +111,12 @@ var cliOptions struct {
 	sslrootcert  string
 	versionTable string
 
-	sshHost     string
-	sshPort     string
-	sshUser     string
-	sshPassword string
+	sshHost       string
+	sshPort       string
+	sshKeyFile    string
+	sshPassphrase string
+	sshUser       string
+	sshPassword   string
 }
 
 func (c *Config) Validate() error {
@@ -332,6 +334,8 @@ func addCoreConfigFlagsToCommand(cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(&cliOptions.sshHost, "ssh-host", "", "", "SSH tunnel host")
 	cmd.Flags().StringVarP(&cliOptions.sshPort, "ssh-port", "", "", "SSH tunnel port")
+	cmd.Flags().StringVarP(&cliOptions.sshKeyFile, "ssh-keyfile", "", "", "Path to SSH key file to use")
+	cmd.Flags().StringVarP(&cliOptions.sshPassphrase, "ssh-passphrase", "", "", "Passphrase for SSH key file (only required if file is encrpyted)")
 	cmd.Flags().StringVarP(&cliOptions.sshUser, "ssh-user", "", "", "SSH tunnel user (default is OS user")
 	cmd.Flags().StringVarP(&cliOptions.sshPassword, "ssh-password", "", "", "SSH tunnel password (unneeded if using SSH agent authentication)")
 }
@@ -1234,6 +1238,12 @@ func appendConfigFromCLIArgs(config *Config) error {
 	}
 	if cliOptions.sshPassword != "" {
 		config.SSHConnConfig.Password = cliOptions.sshPassword
+	}
+	if cliOptions.sshKeyFile != "" {
+		config.SSHConnConfig.KeyFile = cliOptions.sshKeyFile
+	}
+	if cliOptions.sshPassphrase != "" {
+		config.SSHConnConfig.Passphrase = cliOptions.sshPassphrase
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1191,6 +1191,14 @@ func appendConfigFromFile(config *Config, path string) error {
 	if password, ok := file.Get("ssh-tunnel", "password"); ok {
 		config.SSHConnConfig.Password = password
 	}
+
+	if keyfile, ok := file.Get("ssh-tunnel", "keyfile"); ok {
+		config.SSHConnConfig.KeyFile = keyfile
+	}
+
+	if passphrase, ok := file.Get("ssh-tunnel", "passphrase"); ok {
+		config.SSHConnConfig.Passphrase = passphrase
+	}
 	return nil
 }
 

--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/Microsoft/go-winio"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -17,11 +16,6 @@ type SSHConnConfig struct {
 	User     string
 	Password string
 }
-
-const (
-	// Windows does expostthe ssh agent on this pipe
-	sshAgentPipe = `\\.\pipe\openssh-ssh-agent`
-)
 
 func NewSSHClient(config *SSHConnConfig) (*ssh.Client, error) {
 	sshConfig := &ssh.ClientConfig{
@@ -50,16 +44,6 @@ func NewSSHClient(config *SSHConnConfig) (*ssh.Client, error) {
 	}
 
 	return ssh.Dial("tcp", net.JoinHostPort(config.Host, config.Port), sshConfig)
-}
-
-func WindowsSSHAgent() ssh.AuthMethod {
-
-	if sshAgent, err := winio.DialPipe(sshAgentPipe, nil); err == nil {
-		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
-	} else {
-		fmt.Printf("Error opening windows ssh agent: %v", err)
-	}
-	return nil
 }
 
 func SSHAgent() ssh.AuthMethod {

--- a/win_ssh_agent_other.go
+++ b/win_ssh_agent_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import "golang.org/x/crypto/ssh"
+
+func WindowsSSHAgent() ssh.AuthMethod {
+	return nil
+}

--- a/win_ssh_agent_windows.go
+++ b/win_ssh_agent_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+const (
+	// Windows does expostthe ssh agent on this pipe
+	sshAgentPipe = `\\.\pipe\openssh-ssh-agent`
+)
+
+func WindowsSSHAgent() ssh.AuthMethod {
+
+	if sshAgent, err := winio.DialPipe(sshAgentPipe, nil); err == nil {
+		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+	}
+	return nil
+}


### PR DESCRIPTION
I use tern on windows and I am using the native windows ssh agent implementation.
This implementation does not expose the ssh agent on a unix socket, but on a pipe. 
This PR adds another authentication method for ssh tunneling if it detects a native windows pipe.

This adds a direct dependency to `github.com/Microsoft/go-winio` (MIT License)