### PR TITLE
Fix template lookup on Windows

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -163,10 +163,15 @@ func (m *Migrator) LoadMigrations(fsys fs.FS) error {
 		},
 	)
 
-	sharedPaths, err := fs.Glob(fsys, "*/*.sql")
-	if err != nil {
-		return err
-	}
+	var sharedPaths []string
+	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if (!d.IsDir()) &&
+			(filepath.Dir(path) != ".") &&
+			(filepath.Ext(path) == ".sql") {
+			sharedPaths = append(sharedPaths, path)
+		}
+		return nil
+	})
 
 	for _, p := range sharedPaths {
 		body, err := fs.ReadFile(fsys, p)

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -163,7 +163,7 @@ func (m *Migrator) LoadMigrations(fsys fs.FS) error {
 		},
 	)
 
-	sharedPaths, err := fs.Glob(fsys, filepath.Join("*", "*.sql"))
+	sharedPaths, err := fs.Glob(fsys, "*/*.sql")
 	if err != nil {
 		return err
 	}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -149,7 +149,7 @@ func (m *Migrator) LoadMigrations(fsys fs.FS) error {
 	mainTmpl := template.New("main").Funcs(sprig.TxtFuncMap()).Funcs(
 		template.FuncMap{
 			"install_snapshot": func(name string) (string, error) {
-				codePackageFSys, err := fs.Sub(fsys, filepath.Join("snapshots", name))
+				codePackageFSys, err := fs.Sub(fsys, "snapshots/"+name)
 				if err != nil {
 					return "", err
 				}


### PR DESCRIPTION
fixes #111

Do not use `fs.Join(...)` as argument to `fs.Glob(..)`, as it fails on Wiindows.

`fs.Glob()` expects a pattern like `fs.Match()`. On Windows `fs.Join("*", "*.sql")` will produce `"*\\*.sql"` which is not what one wants (` "*/*.sql"`). On Linux `fs.Join("*", "*.sql")` results in`"*/*.sql"` which is a vaild pattern.