### PR TITLE
feat: allow history table creation & usage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -395,6 +395,17 @@ Limitations:
 disable-tx magic comment it will be ignored.
 * Migrations can only go forward to the latest version.
 
+## History table usage
+
+It is possible to log every migration applied (version, time it was applied, content of the migration, ...) using the 
+following configuration, in your tern.conf file:
+
+```
+# history_table = public.schema_history
+```
+
+This is an optional setting and you can plug it on the go, unplug it and plug it again if you want.
+
 ## Running the Tests
 
 To run the tests tern requires two test databases to run migrations against.

--- a/migrate/code_test.go
+++ b/migrate/code_test.go
@@ -21,6 +21,7 @@ func TestLoadCodePackageNotCodePackage(t *testing.T) {
 	assert.EqualError(t, err, "install.sql not found")
 	assert.Nil(t, codePackage)
 }
+
 func TestInstallCodePackage(t *testing.T) {
 	codePackage, err := migrate.LoadCodePackage(os.DirFS("testdata/code"))
 	require.NoError(t, err)


### PR DESCRIPTION
For diverse reasons, I would like to be able to have an history of the migrations run directly in the database. This is made fully optional and can be enabled, disabled & even re-enabled on the fly if people want. I thought it could be beneficial to have it in the main tern library but let me know if this is not something you want & I'll just keep it in my fork.