### PR TITLE
add support for both SQL and Go function migrations

### DIFF
--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -439,7 +439,7 @@ func TestNotCreatingVersionTableIfAlreadyVisibleInSearchPath(t *testing.T) {
 	require.EqualValues(t, 3, mCurrentVersion)
 }
 
-func Example_OnStartMigrationProgressLogging() {
+func Example_onStartMigrationProgressLogging() {
 	conn, err := pgx.Connect(context.Background(), os.Getenv("MIGRATE_TEST_CONN_STRING"))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)

--- a/migrate/step.go
+++ b/migrate/step.go
@@ -1,0 +1,142 @@
+package migrate
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/tern/v2/migrate/internal/sqlsplit"
+)
+
+// A MigrationStep is a database schema state transition. It performs the modifications needed to
+// bring the database schema up from its prior state to the new state (and optionally back down
+// again).
+type MigrationStep interface {
+	// Name is a human-readable name or description of the [Step].
+	Name() string
+	// Sequence is a state identifier for the database schema after the Up method has been
+	// applied for this [Migration].
+	Sequence() int32
+	// DisableTx indicates if this [Migration] cannot be run inside a transaction. Some SQL
+	// statements such as `create index concurrently` cannot run within a transaction. If the
+	// return value is true, the [Migrator] won't start a transaction for the [pgx.Conn] passed
+	// to [Up] (or [Down]).
+	DisableTx() bool
+	// Up performs the database operations necessary to bring the database from its prior state
+	// to a state that includes the modifications performed by this [Migration]. The [pgx.Conn]
+	// may or may not be running in the context of a transaction depending on [DisableTx].
+	Up(ctx context.Context, conn *pgx.Conn) error
+	// Down performs the database operations necessary to bring the database back to its prior
+	// state by undoing the modifications of this [Migration]. The [pgx.Conn] may or may not be
+	// running in the context of a transaction depending on [DisableTx].
+	//
+	// If this [MigrationStep] cannot be undone a [IrreversibleMigrationError] will be returned.
+	Down(ctx context.Context, conn *pgx.Conn) error
+}
+
+// SQLMigrationStep is a specialization of a [MigrationStep] for a migration that is entirely
+// defined with SQL statements (no custom code execution).
+type SQLMigrationStep interface {
+	MigrationStep
+
+	UpSQL() string
+	DownSQL() string
+}
+
+// SQL defines a declarative, entirely SQL-based, migration that can be passed to the [SQLStep]
+// function to produce an [SQLMigrationStep].
+type SQL struct {
+	Sequence int32
+	Name     string
+	UpSQL    string
+	DownSQL  string
+}
+
+// SQLStep creates a [MigrationStep] that uses declarative SQL statements to define migration
+// operations.
+func SQLStep(s SQL) *sqlMigrationStep {
+	return &sqlMigrationStep{sequence: s.Sequence, name: s.Name, upSQL: s.UpSQL, downSQL: s.DownSQL}
+}
+
+var _ MigrationStep = &sqlMigrationStep{}
+var _ SQLMigrationStep = &sqlMigrationStep{}
+
+type sqlMigrationStep struct {
+	sequence int32
+	name     string
+	upSQL    string
+	downSQL  string
+}
+
+func (m *sqlMigrationStep) Name() string { return m.name }
+
+func (m *sqlMigrationStep) Sequence() int32 { return m.sequence }
+
+func (m *sqlMigrationStep) UpSQL() string { return m.upSQL }
+
+func (m *sqlMigrationStep) DownSQL() string { return m.downSQL }
+
+func (m *sqlMigrationStep) DisableTx() bool { return disableTxPattern.MatchString(m.upSQL) }
+
+func (m *sqlMigrationStep) Up(ctx context.Context, conn *pgx.Conn) error {
+	return m.connExec(ctx, conn, m.statements(m.upSQL))
+}
+
+func (m *sqlMigrationStep) Down(ctx context.Context, conn *pgx.Conn) error {
+	if m.downSQL == "" {
+		return IrreversibleMigrationError{m: m}
+	}
+	return m.connExec(ctx, conn, m.statements(m.downSQL))
+}
+
+func (m *sqlMigrationStep) connExec(ctx context.Context, conn *pgx.Conn, sqlStatements []string) error {
+	for _, statement := range sqlStatements {
+		if _, err := conn.Exec(ctx, statement); err != nil {
+			if err, ok := err.(*pgconn.PgError); ok {
+				return MigrationPgError{MigrationName: m.name, Sql: statement, PgError: err}
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *sqlMigrationStep) statements(sql string) []string {
+	sql = disableTxPattern.ReplaceAllLiteralString(sql, "")
+	if m.DisableTx() {
+		return sqlsplit.Split(sql)
+	}
+	return []string{sql}
+}
+
+// TxFunc defines a function/code-based migration that can be passed to the [FuncStep] function to
+// produce a [MigrationStep].
+type TxFunc struct {
+	Sequence int32
+	Name     string
+	Up       func(context.Context, *pgx.Conn) error
+	Down     func(context.Context, *pgx.Conn) error
+}
+
+// FuncStep creates a [MigrationStep] that uses code (functions) to perform migration operations.
+func FuncStep(fn TxFunc) *txFuncMigrationStep {
+	return &txFuncMigrationStep{txFunc: fn}
+}
+
+var _ MigrationStep = &txFuncMigrationStep{}
+
+type txFuncMigrationStep struct{ txFunc TxFunc }
+
+func (m *txFuncMigrationStep) Name() string { return m.txFunc.Name }
+
+func (m *txFuncMigrationStep) Sequence() int32 { return m.txFunc.Sequence }
+
+func (m *txFuncMigrationStep) DisableTx() bool { return false }
+
+func (m *txFuncMigrationStep) Up(ctx context.Context, conn *pgx.Conn) error {
+	return m.txFunc.Up(ctx, conn)
+}
+
+func (m *txFuncMigrationStep) Down(ctx context.Context, conn *pgx.Conn) error {
+	return m.txFunc.Down(ctx, conn)
+}


### PR DESCRIPTION
First off, thanks for all the effort put into this great library (not to mention `pgx`!). We are long-term users of the library and have been very happy with it so far. We mainly use `tern` as a library, built into our micro-service applications.

One thing that we, at times, have missed though is the ability to run migrations that involve more complex code logic (not just SQL statements).

Although pure SQL-based migrations are preferable most of the time, there are situations where it is impractical to write migrations entirely in PL/pgSQL. For example when the pgSQL code would need to re-implement complex parsing/logic already available in Go library code.

This PR is an attempt to extend the `migrate` library to support _both_ SQL-based migrations _and_ function-based migrations. Consider everything suggestions at this point (the feature itself, naming, and code structure). In its current shape it runs the existing tests successfully. Before I write more tests to cover the new functionality I thought I'd wait to see how it's received.

To summarize, the changes are as follows:

- Updates the `migrate` library to support arbitrary Go function migrations.
- Introduces a new interface `migrate.MigrationStep` and two implementations:
  - `migrate.FuncStep`
  - `migrate.SQLStep`
- Remains backwards-compatible, but deprecates the `migrate.Migration` type and `migrate.AppendMigration` method.

The following code snippet illustrates how the code can be used:

```go
	// Note: requires environment variables to be set: PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD.
	conn, _ := pgx.Connect(ctx, "")
	m, _ := migrate.NewMigrator(context.Background(), conn, "schema_version_table")

	m.AppendSteps(
		migrate.FuncStep(migrate.TxFunc{
			Sequence: 1,
			Name:     "1",
			Up: func(ctx context.Context, conn *pgx.Conn) error {
				// Can execute any code logic wrapped inside a transaction.
				_, err := conn.Exec(ctx, "CREATE TABLE t1 (id INT PRIMARY KEY);")
				return err
			},
			Down: func(ctx context.Context, conn *pgx.Conn) error {
				_, err := conn.Exec(ctx, "DROP TABLE t1;")
				return err
			}}),
		migrate.SQLStep(migrate.SQL{
			Sequence: 2,
			Name:     "2",
			UpSQL:    `CREATE TABLE t2 (id INT);`,
			DownSQL:  `DROP TABLE t2;`}))

	_ = m.Migrate(ctx)
```
