### PR TITLE
support Migrations with Go functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,8 @@ workflow for managing database code such as functions and views.
 ## Features
 
 * Multi-platform
-* Stand-alone binary
+* Use as stand-alone binary or library
+* Supports both SQL migrations and Go function migrations
 * SSH tunnel support built-in
 * Data variable interpolation into migrations
 
@@ -362,9 +363,54 @@ Tern will automatically use an SSH agent or `~/.ssh/id_dsa`, `~/.ssh/id_rsa`,
 
 ## Embedding Tern
 
-All the actual functionality of tern is in the github.com/jackc/tern/v2/migrate
+All the actual functionality of tern is in the `github.com/jackc/tern/v2/migrate`
 library. If you need to embed migrations into your own application this
 library can help. If you don't need the full functionality of tern, then a migration generator script as described below may be a easier way of embedding simple migrations.
+
+The sample code below shows how a `migrate.Migrator` can be set up to perform migration steps both as Go functions or as pure SQL statements.
+
+```go
+	// Note: requires the right mix of environment variables to be set: PGHOST, PGPORT, PGDATABASE,
+	// PGUSER, PGPASSWORD.
+	conn, _ = pgx.Connect(ctx, "")
+	m, _ = migrate.NewMigrator(context.Background(), conn, "my_schema_version")
+
+	m.Migrations = []*migrate.Migration{
+		// Migration that uses Go functions.
+		{
+			Sequence: 1,
+			Name:     "1",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "CREATE TABLE tmp (id INT);")
+				return err
+			},
+			DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "DROP TABLE tmp;")
+				return err
+			},
+		},
+		// Migration that uses SQL.
+		{
+			Sequence: 2,
+			Name:     "2",
+			UpSQL:    `CREATE TABLE tmp2 (id INT);`,
+			DownSQL:  `DROP TABLE tmp2;`,
+		},
+
+		// Migration that uses both Go function and SQL.
+		{
+			Sequence: 3,
+			Name:     "3",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "CREATE TABLE tmp3 (id INT);")
+				return err
+			},
+			DownSQL: `DROP TABLE tmp3;`,
+		},
+	}
+
+	_ = m.Migrate(ctx)
+```
 
 ## Generating a Migration Generator SQL Script
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -326,10 +326,6 @@ func (m *Migrator) Migrate(ctx context.Context) error {
 
 // validate returns an error if the [Migrator] is set up in an incoherent way.
 func (m *Migrator) validate() error {
-	if len(m.Migrations) == 0 {
-		return fmt.Errorf("cannot migrate an empty sequence of migrations")
-	}
-
 	for _, m := range m.Migrations {
 		if m.UpSQL != "" && m.UpFunc != nil {
 			return fmt.Errorf("cannot specify both UpSQL and UpFunc for a migration")

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -23,6 +23,11 @@ var (
 	disableTxPattern = regexp.MustCompile(`(?m)^---- tern: disable-tx ----$`)
 )
 
+const (
+	up   = "up"
+	down = "down"
+)
+
 var ErrNoFwMigration = errors.New("no sql in forward migration step")
 
 type BadVersionError string
@@ -62,11 +67,58 @@ func (e MigrationPgError) Unwrap() error {
 	return e.PgError
 }
 
+// MigrationFunc can be used to define a [Migration] using a Go function.
+type MigrationFunc func(ctx context.Context, conn *pgx.Conn) error
+
+// A Migration is a database schema state transition. It performs the modifications needed to bring
+// the database schema up from its prior state to the new state (and optionally back down again).
 type Migration struct {
+	// Sequence is a state identifier for the database schema after the up direction of the
+	// [Migration] has been applied.
 	Sequence int32
-	Name     string
-	UpSQL    string
-	DownSQL  string
+	// Name is a human-readable name or description of the [Migration].
+	Name string
+
+	// UpSQL declares SQL statements that brings the database up from its prior [Migration]
+	// state. Cannot be used together with [UpFunc].
+	UpSQL string
+	// DownSQL declares SQL statements that brings the database back down to its prior
+	// [Migration] state. Cannot be used together with [DownFunc].
+	DownSQL string
+
+	// UpFunc is a Go function that brings the database up from its prior state [Migration]
+	// state. Cannot be used together with [UpSQL].
+	UpFunc MigrationFunc
+	// DownFunc is a Go function that brings the database back down to its prior [Migration]
+	// state. Cannot be used together with [DownSQL].
+	DownFunc MigrationFunc
+}
+
+// isSQL returns true if the [Migration] is an SQL-based one in the given direction ([up] or
+// [down]). That is, one defined in terms of [Migration.UpSQL] or [Migration.DownSQL].
+func (m *Migration) isSQL(direction string) bool {
+	if direction == up {
+		return m.UpSQL != ""
+	}
+	return m.DownSQL != ""
+}
+
+// wantTx returns true if the [Migration] wants to run in a transaction. The direction can either be
+// [up] or [down].
+func (m *Migration) wantTx(direction string) bool {
+	if !m.isSQL(direction) {
+		// We always want a transaction for function-based transactions.
+		return true
+	}
+	if direction == up {
+		return !disableTxPattern.MatchString(m.UpSQL)
+	}
+	return !disableTxPattern.MatchString(m.DownSQL)
+}
+
+// irreversible returns true if the [Migration] cannot be undone.
+func (m *Migration) irreversible() bool {
+	return m.DownSQL == "" && m.DownFunc == nil
 }
 
 type MigratorOptions struct {
@@ -266,7 +318,30 @@ func (m *Migrator) AppendMigration(name, upSQL, downSQL string) {
 // Migrate runs pending migrations
 // It calls m.OnStart when it begins a migration
 func (m *Migrator) Migrate(ctx context.Context) error {
-	return m.MigrateTo(ctx, int32(len(m.Migrations)))
+	if err := m.validate(); err != nil {
+		return err
+	}
+	return m.MigrateTo(ctx, m.highestSequenceNum())
+}
+
+// validate returns an error if the [Migrator] is set up in an incoherent way.
+func (m *Migrator) validate() error {
+	if len(m.Migrations) == 0 {
+		return fmt.Errorf("cannot migrate an empty sequence of migrations")
+	}
+
+	for _, m := range m.Migrations {
+		if m.UpSQL != "" && m.UpFunc != nil {
+			return fmt.Errorf("cannot specify both UpSQL and UpFunc for a migration")
+		}
+		if m.UpSQL == "" && m.UpFunc == nil {
+			return fmt.Errorf("must specify either UpSQL or UpFunc for a migration")
+		}
+		if m.DownSQL != "" && m.DownFunc != nil {
+			return fmt.Errorf("cannot specify both DownSQL and DownFunc for a migration")
+		}
+	}
+	return nil
 }
 
 // Lock to ensure multiple migrations cannot occur simultaneously
@@ -284,6 +359,10 @@ func releaseAdvisoryLock(ctx context.Context, conn *pgx.Conn) error {
 
 // MigrateTo migrates to targetVersion
 func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err error) {
+	if err := m.validate(); err != nil {
+		return err
+	}
+
 	err = acquireAdvisoryLock(ctx, m.conn)
 	if err != nil {
 		return err
@@ -311,42 +390,41 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err erro
 	}
 
 	var direction int32
+	var directionName string
 	if currentVersion < targetVersion {
 		direction = 1
+		directionName = up
 	} else {
 		direction = -1
+		directionName = down
 	}
 
 	for currentVersion != targetVersion {
 		var current *Migration
-		var sql, directionName string
+		var sql string
 		var sequence int32
+		var migrateFunc MigrationFunc // Will do the migration step.
 		if direction == 1 {
 			current = m.Migrations[currentVersion]
 			sequence = current.Sequence
 			sql = current.UpSQL
-			directionName = "up"
+			if !current.isSQL(directionName) {
+				migrateFunc = current.UpFunc
+			}
 		} else {
 			current = m.Migrations[currentVersion-1]
-			sequence = current.Sequence - 1
-			sql = current.DownSQL
-			directionName = "down"
-			if current.DownSQL == "" {
+			if current.irreversible() {
 				return IrreversibleMigrationError{m: current}
 			}
+			sequence = current.Sequence - 1
+			sql = current.DownSQL
+			if !current.isSQL(directionName) {
+				migrateFunc = current.DownFunc
+			}
 		}
-
-		useTx := !m.options.DisableTx
-		var sqlStatements []string
-		if disableTxPattern.MatchString(sql) {
-			useTx = false
-			sql = disableTxPattern.ReplaceAllLiteralString(sql, "")
-		}
-
-		if useTx {
-			sqlStatements = []string{sql}
-		} else {
-			sqlStatements = sqlsplit.Split(sql)
+		useTx := !m.options.DisableTx && current.wantTx(directionName)
+		if current.isSQL(directionName) {
+			migrateFunc = sqlFunc(current, directionName, useTx)
 		}
 
 		var tx pgx.Tx
@@ -363,15 +441,9 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int32) (err erro
 			m.OnStart(current.Sequence, current.Name, directionName, sql)
 		}
 
-		// Execute the migration
-		for _, statement := range sqlStatements {
-			_, err = m.conn.Exec(ctx, statement)
-			if err != nil {
-				if err, ok := err.(*pgconn.PgError); ok {
-					return MigrationPgError{MigrationName: current.Name, Sql: statement, PgError: err}
-				}
-				return err
-			}
+		// Execute the migration.
+		if err := migrateFunc(ctx, m.conn); err != nil {
+			return err
 		}
 
 		// Reset all database connection settings. Important to do before updating version as search_path may have been changed.
@@ -438,6 +510,12 @@ func (m *Migrator) versionTableExists(ctx context.Context) (ok bool, err error) 
 	return count > 0, err
 }
 
+// highestSequenceNum returns the highest sequence number of any [Migration] handled by the
+// [Migrator].
+func (m *Migrator) highestSequenceNum() int32 {
+	return m.Migrations[len(m.Migrations)-1].Sequence
+}
+
 func setAt(strs []string, value string, pos int64) []string {
 	// If pos > length - 1, append empty strings to make it the right size
 	if pos > int64(len(strs))-1 {
@@ -445,4 +523,29 @@ func setAt(strs []string, value string, pos int64) []string {
 	}
 	strs[pos] = value
 	return strs
+}
+
+// sqlFunc creates a [MigrationFunc] for the supplied SQL-based [Migration] in the given direction
+// ([up] or [down]).
+func sqlFunc(m *Migration, directionName string, useTx bool) MigrationFunc {
+	sql := m.UpSQL
+	if directionName == down {
+		sql = m.DownSQL
+	}
+	return func(ctx context.Context, conn *pgx.Conn) error {
+		sqlStatements := []string{sql}
+		if !useTx {
+			sqlStatements = sqlsplit.Split(sql)
+		}
+		// Execute the migration
+		for _, statement := range sqlStatements {
+			if _, err := conn.Exec(ctx, statement); err != nil {
+				if err, ok := err.(*pgconn.PgError); ok {
+					return MigrationPgError{MigrationName: m.Name, Sql: statement, PgError: err}
+				}
+				return err
+			}
+		}
+		return nil
+	}
 }

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -83,6 +83,74 @@ func createSampleMigrator(t testing.TB, conn *pgx.Conn) *migrate.Migrator {
 	return m
 }
 
+func createGoFuncMigrator(t testing.TB, conn *pgx.Conn) *migrate.Migrator {
+	m := createEmptyMigrator(t, conn)
+	m.Migrations = []*migrate.Migration{
+		{
+			Sequence: 1,
+			Name:     "Create t1",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "create table t1(id serial);")
+				return err
+			},
+			DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "drop table t1;")
+				return err
+			},
+		},
+		{
+			Sequence: 2,
+			Name:     "Create t2",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "create table t2(id serial);")
+				return err
+			},
+			DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "drop table t2;")
+				return err
+			},
+		},
+		{
+			Sequence: 3,
+			Name:     "Create t3",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "create table t3(id serial);")
+				return err
+			},
+			DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "drop table t3;")
+				return err
+			},
+		},
+	}
+	return m
+}
+
+func createMixedSQLAndGoFuncMigrator(t testing.TB, conn *pgx.Conn) *migrate.Migrator {
+	m := createEmptyMigrator(t, conn)
+	m.Migrations = []*migrate.Migration{
+		{
+			Sequence: 1,
+			Name:     "Create t1",
+			UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "create table t1(id serial);")
+				return err
+			},
+			DownSQL: "drop table t1;",
+		},
+		{
+			Sequence: 2,
+			Name:     "Create t2",
+			UpSQL:    "create table t2(id serial);",
+			DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+				_, err := conn.Exec(ctx, "drop table t2;")
+				return err
+			},
+		},
+	}
+	return m
+}
+
 func TestNewMigrator(t *testing.T) {
 	conn := connectConn(t)
 	defer conn.Close(context.Background())
@@ -102,6 +170,58 @@ func TestNewMigrator(t *testing.T) {
 	initialVersion, err := m.GetCurrentVersion(context.Background())
 	assert.NoError(t, err)
 	require.EqualValues(t, 0, initialVersion)
+}
+
+func TestMigrationValidation(t *testing.T) {
+	conn := connectConn(t)
+	defer conn.Close(context.Background())
+
+	t.Run("must not specify both UpSQL and UpFunc", func(t *testing.T) {
+		m := createEmptyMigrator(t, conn)
+		m.Migrations = []*migrate.Migration{
+			{
+				Sequence: 1, Name: "M1",
+				UpSQL: "create table t1(id serial);",
+				UpFunc: func(ctx context.Context, conn *pgx.Conn) error {
+					_, err := conn.Exec(ctx, "create table t1(id serial);")
+					return err
+				},
+			},
+		}
+		err := m.Migrate(context.Background())
+		assert.Error(t, err)
+		assert.EqualError(t, err, "cannot specify both UpSQL and UpFunc for a migration")
+	})
+
+	t.Run("must specify either UpSQL or UpFunc", func(t *testing.T) {
+		m := createEmptyMigrator(t, conn)
+		m.Migrations = []*migrate.Migration{
+			{
+				Sequence: 1, Name: "M1",
+			},
+		}
+		err := m.Migrate(context.Background())
+		assert.Error(t, err)
+		assert.EqualError(t, err, "must specify either UpSQL or UpFunc for a migration")
+	})
+
+	t.Run("must not specify both DownSQL and DownFunc", func(t *testing.T) {
+		m := createEmptyMigrator(t, conn)
+		m.Migrations = []*migrate.Migration{
+			{
+				Sequence: 1, Name: "M1",
+				UpSQL:   "create table t1(id serial);",
+				DownSQL: "drop table t1;",
+				DownFunc: func(ctx context.Context, conn *pgx.Conn) error {
+					_, err := conn.Exec(ctx, "drop table t1;")
+					return err
+				},
+			},
+		}
+		err := m.Migrate(context.Background())
+		assert.Error(t, err)
+		assert.EqualError(t, err, "cannot specify both DownSQL and DownFunc for a migration")
+	})
 }
 
 func TestAppendMigration(t *testing.T) {
@@ -223,6 +343,44 @@ func TestMigrate(t *testing.T) {
 	assert.NoError(t, err)
 	currentVersion := currentVersion(t, conn)
 	assert.EqualValues(t, 3, currentVersion)
+}
+
+func TestMigrateUsingGoFunctions(t *testing.T) {
+	conn := connectConn(t)
+	defer conn.Close(context.Background())
+	m := createGoFuncMigrator(t, conn)
+
+	// Migrate up
+	assert.NoError(t, m.Migrate(context.Background()))
+	assert.EqualValues(t, 3, currentVersion(t, conn))
+	assert.True(t, tableExists(t, conn, "t1"))
+	assert.True(t, tableExists(t, conn, "t2"))
+	assert.True(t, tableExists(t, conn, "t3"))
+
+	// Migrate down
+	assert.NoError(t, m.MigrateTo(context.Background(), 0))
+	assert.EqualValues(t, 0, currentVersion(t, conn))
+	assert.False(t, tableExists(t, conn, "t1"))
+	assert.False(t, tableExists(t, conn, "t2"))
+	assert.False(t, tableExists(t, conn, "t3"))
+}
+
+func TestMigrateUsingMixedSQLAndGoFunctions(t *testing.T) {
+	conn := connectConn(t)
+	defer conn.Close(context.Background())
+	m := createMixedSQLAndGoFuncMigrator(t, conn)
+
+	// Migrate up
+	assert.NoError(t, m.Migrate(context.Background()))
+	assert.EqualValues(t, 2, currentVersion(t, conn))
+	assert.True(t, tableExists(t, conn, "t1"))
+	assert.True(t, tableExists(t, conn, "t2"))
+
+	// Migrate down
+	assert.NoError(t, m.MigrateTo(context.Background(), 0))
+	assert.EqualValues(t, 0, currentVersion(t, conn))
+	assert.False(t, tableExists(t, conn, "t1"))
+	assert.False(t, tableExists(t, conn, "t2"))
 }
 
 func TestMigrateToLifeCycle(t *testing.T) {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -439,7 +439,7 @@ func TestNotCreatingVersionTableIfAlreadyVisibleInSearchPath(t *testing.T) {
 	require.EqualValues(t, 3, mCurrentVersion)
 }
 
-func Example_OnStartMigrationProgressLogging() {
+func Example_onStartMigrationProgressLogging() {
 	conn, err := pgx.Connect(context.Background(), os.Getenv("MIGRATE_TEST_CONN_STRING"))
 	if err != nil {
 		fmt.Printf("Unable to establish connection: %v", err)


### PR DESCRIPTION
New attempt at adding support for Go functions (after push-back on https://github.com/jackc/tern/pull/121).

Thi PR adds `UpFunc` and `DownFunc` directly to the `Migration` struct.