### PR TITLE
Cockroach migration locking workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ testdata/tern.conf
 /tern
 /tmp
 
+.vscode
 .idea/*
 dist

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,12 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
 github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.7.4 h1:9wKznZrhWa2QiHL+NjTSPP6yjl3451BX3imWDnokYlg=
+github.com/jackc/pgx/v5 v5.7.4/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/main.go
+++ b/main.go
@@ -95,12 +95,13 @@ type Config struct {
 }
 
 var cliOptions struct {
-	destinationVersion string
-	currentVersion     string
-	migrationsPath     string
-	configPaths        []string
-	editNewMigration   bool
-	outputFile         string // used for gengen or print-migrations
+	destinationVersion       string
+	currentVersion           string
+	migrationsPath           string
+	configPaths              []string
+	editNewMigration         bool
+	outputFile               string // used for gengen or print-migrations
+	cockroachDbCompatible bool
 
 	connString   string
 	host         string
@@ -187,6 +188,7 @@ The word "last":
 		Run: Migrate,
 	}
 	cmdMigrate.Flags().StringVarP(&cliOptions.destinationVersion, "destination", "d", "last", "destination migration version")
+	cmdMigrate.Flags().BoolVar(&cliOptions.cockroachDbCompatible, "cockroachdb", false, "CockroachDB compatibility flag avoiding advisory locks (default is false)")
 	addConfigFlagsToCommand(cmdMigrate)
 
 	cmdCode := &cobra.Command{
@@ -507,7 +509,9 @@ func Migrate(cmd *cobra.Command, args []string) {
 	config, conn := loadConfigAndConnectToDB(ctx)
 	defer conn.Close(ctx)
 
-	migrator, err := migrate.NewMigrator(ctx, conn, config.VersionTable)
+	migOpts := migrate.MigratorOptions{ CockroachDbCompatible: cliOptions.cockroachDbCompatible }
+
+	migrator, err := migrate.NewMigrator(ctx, conn, config.VersionTable, &migOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 		os.Exit(1)
@@ -612,7 +616,9 @@ func Gengen(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	migrator, err := migrate.NewMigrator(context.Background(), nil, config.VersionTable)
+	migOpts := migrate.MigratorOptions{ CockroachDbCompatible: cliOptions.cockroachDbCompatible }
+
+	migrator, err := migrate.NewMigrator(context.Background(), nil, config.VersionTable, &migOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 		os.Exit(1)
@@ -863,7 +869,9 @@ func Status(cmd *cobra.Command, args []string) {
 	config, conn := loadConfigAndConnectToDB(ctx)
 	defer conn.Close(ctx)
 
-	migrator, err := migrate.NewMigrator(ctx, conn, config.VersionTable)
+	migOpts := migrate.MigratorOptions{ CockroachDbCompatible: cliOptions.cockroachDbCompatible }
+
+	migrator, err := migrate.NewMigrator(ctx, conn, config.VersionTable, &migOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 		os.Exit(1)
@@ -1307,7 +1315,8 @@ func PrintMigrations(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "Error connecting to database:\n  %v\n", err)
 			os.Exit(1)
 		}
-		migrator, err = migrate.NewMigrator(ctx, conn, config.VersionTable)
+		migOpts := migrate.MigratorOptions{ CockroachDbCompatible: cliOptions.cockroachDbCompatible }
+		migrator, err = migrate.NewMigrator(ctx, conn, config.VersionTable, &migOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 			os.Exit(1)
@@ -1321,7 +1330,8 @@ func PrintMigrations(cmd *cobra.Command, args []string) {
 		}
 		currentVersion = int32(n)
 
-		migrator, err = migrate.NewMigrator(ctx, nil, config.VersionTable)
+		migOpts := migrate.MigratorOptions{ CockroachDbCompatible: cliOptions.cockroachDbCompatible }
+		migrator, err = migrate.NewMigrator(ctx, nil, config.VersionTable, &migOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
Adds a new locking semantic with a dedicated conn/tx locking on the row with value -1

updates the bootstrap schema_version table to include this row and also enables partitions to prevent contention with negative and positive values

added flag --cockroachdb to enable

replace NewMigratorEx with simply NewMigrator

Allow disable of row locks during a migration, particularly necessary on cockroach with functions as they're a schema change

guards lock from recursive calls

abstract locking/releasing from the lock type