### PR TITLE
Fix migrate.LoadMigrations panic (nil pointer dereference) when directory doesn't exist

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -223,14 +223,19 @@ func (m *Migrator) LoadMigrations(fsys fs.FS) error {
 	)
 
 	var sharedPaths []string
-	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if (!d.IsDir()) &&
 			(filepath.Dir(path) != ".") &&
 			(filepath.Ext(path) == ".sql") {
 			sharedPaths = append(sharedPaths, path)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	for _, p := range sharedPaths {
 		body, err := fs.ReadFile(fsys, p)

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -240,14 +240,14 @@ func TestAppendMigration(t *testing.T) {
 	assert.Equal(t, m.Migrations[0].DownSQL, downSQL)
 }
 
-// func TestLoadMigrationsMissingDirectory(t *testing.T) {
-// 	conn := connectConn(t)
-// 	defer conn.Close(context.Background())
-// 	m := createEmptyMigrator(t, conn)
+func TestLoadMigrationsMissingDirectory(t *testing.T) {
+	conn := connectConn(t)
+	defer conn.Close(context.Background())
+	m := createEmptyMigrator(t, conn)
 
-// 	err := m.LoadMigrations("testdata/missing")
-// 	require.EqualError(t, err, "open testdata/missing: no such file or directory")
-// }
+	err := m.LoadMigrations(os.DirFS("testdata/invalid"))
+	require.EqualError(t, err, "stat .: no such file or directory")
+}
 
 func TestLoadMigrationsEmptyDirectory(t *testing.T) {
 	conn := connectConn(t)


### PR DESCRIPTION
Caveat: using os.DirFS we lose the original path. I've tried to see if we could recover it somehow, but nope...