### PR TITLE
Fix nested code package paths on Windows (use path.Join for fs.FS paths)

### DIFF
--- a/migrate/code.go
+++ b/migrate/code.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"text/template"
 
@@ -48,7 +49,7 @@ func findCodeFiles(fsys fs.FS) ([]string, error) {
 			}
 
 			for _, p := range paths {
-				results = append(results, filepath.Join(e.Name(), p))
+				results = append(results, path.Join(e.Name(), p))
 			}
 		} else {
 			match, err := filepath.Match("*.sql", e.Name())

--- a/migrate/code_test.go
+++ b/migrate/code_test.go
@@ -16,6 +16,12 @@ func TestLoadCodePackage(t *testing.T) {
 	assert.NotNil(t, codePackage)
 }
 
+func TestLoadCodePackageNestedPaths(t *testing.T) {
+	codePackage, err := migrate.LoadCodePackage(os.DirFS("testdata/code_nested"))
+	assert.NoError(t, err)
+	assert.NotNil(t, codePackage)
+}
+
 func TestLoadCodePackageNotCodePackage(t *testing.T) {
 	codePackage, err := migrate.LoadCodePackage(os.DirFS("testdata/sample"))
 	assert.EqualError(t, err, "install.sql not found")

--- a/migrate/testdata/code_nested/install.sql
+++ b/migrate/testdata/code_nested/install.sql
@@ -1,0 +1,2 @@
+{{ template "subfolder/add.sql" . }}
+{{ template "magic_number.sql" . }}

--- a/migrate/testdata/code_nested/magic_number.sql
+++ b/migrate/testdata/code_nested/magic_number.sql
@@ -1,0 +1,8 @@
+drop function if exists magic_number();
+
+create function magic_number() returns int
+language plpgsql as $$
+begin
+  return {{.magic_number}};
+end;
+$$;

--- a/migrate/testdata/code_nested/subfolder/add.sql
+++ b/migrate/testdata/code_nested/subfolder/add.sql
@@ -1,0 +1,8 @@
+drop function if exists add(int, int);
+
+create function add(int, int) returns int
+language plpgsql as $$
+begin
+  return $1 + $2;
+end;
+$$;


### PR DESCRIPTION
Fixes a Windows-specific issue when loading code packages with nested files.

`findCodeFiles` builds internal paths using filepath.Join, which produces
backslash-separated paths on Windows (e.g. `functions\foo.sql`). However, `fs.FS`
expects slash-separated paths (`functions/foo.sql`).

As a result, loading code packages with nested directories fails on Windows.

Use `path.Join` instead of `filepath.Join` when building `fs.FS` paths.
Add a test to ensure nested code packages load correctly across platforms.

This is similar to the issue fixed in #112, but in the code package loader.