### PR TITLE
Add override-version command for baselining existing databases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -219,6 +219,31 @@ To use a different migrations directory:
 
     tern migrate --migrations path/to/migrations
 
+## Baselining an Existing Database
+
+When adopting tern on a database that already has a schema, you cannot simply
+run `tern migrate` because the objects the migrations would create already
+exist. `tern override-version` sets the migration version in the version table
+without running any migrations, allowing you to mark the current schema state
+as a specific version.
+
+The typical workflow is:
+
+1. Write a migration that represents the current schema.
+2. Run `tern override-version N` where N is the sequence number of that
+   migration.
+3. From this point on, `tern migrate` works normally for subsequent
+   migrations.
+
+```
+tern override-version 1
+```
+
+Note that `tern migrate -d <lower>` cannot roll back through migrations that
+were skipped via `override-version` — the down SQL would try to drop tables
+that were never created. To adjust the version after an override, use another
+`override-version` call.
+
 ## Renumbering Conflicting Migrations
 
 When migrations are created on multiple branches the migrations need to be renumbered when the branches are merged. The

--- a/main.go
+++ b/main.go
@@ -316,6 +316,18 @@ it do any error handling
 	cmdPrintMigrations.Flags().StringVarP(&cliOptions.migrationsPath, "migrations", "m", "", "migrations path (default is .)")
 	cmdPrintMigrations.Flags().StringVarP(&cliOptions.outputFile, "output", "o", "", "output file")
 
+	cmdOverrideVersion := &cobra.Command{
+		Use:   "override-version VERSION",
+		Short: "Override the current migration version without running migrations",
+		Long: `Override the current migration version without running any migrations.
+
+This is useful for baselining an existing database when adopting tern.
+You can create a migration representing the current schema and override
+the version to that without actually executing the migration.`,
+		Run: OverrideVersion,
+	}
+	addConfigFlagsToCommand(cmdOverrideVersion)
+
 	cmdVersion := &cobra.Command{
 		Use:   "version",
 		Short: "Print version",
@@ -341,6 +353,7 @@ it do any error handling
 	rootCmd.AddCommand(cmdNew)
 	rootCmd.AddCommand(cmdGengen)
 	rootCmd.AddCommand(cmdPrintMigrations)
+	rootCmd.AddCommand(cmdOverrideVersion)
 	rootCmd.AddCommand(cmdVersion)
 	rootCmd.Execute()
 }
@@ -899,6 +912,57 @@ func Status(cmd *cobra.Command, args []string) {
 	fmt.Printf("version:  %d of %d\n", migrationVersion, len(migrator.Migrations))
 	fmt.Println("host:    ", config.ConnConfig.Host)
 	fmt.Println("database:", config.ConnConfig.Database)
+}
+
+func OverrideVersion(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Help()
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	targetVersion, err := strconv.ParseInt(args[0], 10, 32)
+	if errors.Is(err, strconv.ErrRange) {
+		fmt.Fprintf(os.Stderr, "Error: version %q is out of range\n", args[0])
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %q is not a valid version number\n", args[0])
+		os.Exit(1)
+	}
+	if targetVersion < 0 {
+		fmt.Fprintln(os.Stderr, "Error: version must be non-negative")
+		os.Exit(1)
+	}
+
+	config, conn := loadConfigAndConnectToDB(ctx)
+	defer conn.Close(ctx)
+
+	migrator, err := migrate.NewMigrator(ctx, conn, config.VersionTable)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing migrator:\n  %v\n", err)
+		os.Exit(1)
+	}
+
+	currentVersion, err := migrator.GetCurrentVersion(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving migration version:\n  %v\n", err)
+		os.Exit(1)
+	}
+
+	if int64(currentVersion) == targetVersion {
+		fmt.Printf("version already at %d\n", targetVersion)
+		return
+	}
+
+	err = migrator.SetVersion(ctx, int32(targetVersion))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error overriding version:\n  %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("version overridden: %d → %d\n", currentVersion, targetVersion)
 }
 
 func RenumberStart(cmd *cobra.Command, args []string) {

--- a/main.go
+++ b/main.go
@@ -323,7 +323,11 @@ it do any error handling
 
 This is useful for baselining an existing database when adopting tern.
 You can create a migration representing the current schema and override
-the version to that without actually executing the migration.`,
+the version to that without actually executing the migration.
+
+Note: tern migrate can only roll down through migrations that were
+actually applied. After an override, rolling back requires another
+override-version call rather than tern migrate -d <lower>.`,
 		Run: OverrideVersion,
 	}
 	addConfigFlagsToCommand(cmdOverrideVersion)
@@ -538,7 +542,9 @@ func Migrate(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	var lastDirection string
 	migrator.OnStart = func(sequence int32, name, direction, sql string) {
+		lastDirection = direction
 		fmt.Printf("%s executing %s %s\n%s\n\n", time.Now().Format("2006-01-02 15:04:05"), name, direction, sql)
 	}
 
@@ -608,6 +614,13 @@ func Migrate(cmd *cobra.Command, args []string) {
 		} else {
 			fmt.Fprintln(os.Stderr, err)
 		}
+
+		if lastDirection == "down" {
+			fmt.Fprintln(os.Stderr, "\nHint: if you previously used `tern override-version`, the migration")
+			fmt.Fprintln(os.Stderr, "may never have been applied. Use `tern override-version <n>` to")
+			fmt.Fprintln(os.Stderr, "adjust the version without executing migrations.")
+		}
+
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -901,10 +901,16 @@ func Status(cmd *cobra.Command, args []string) {
 	}
 
 	var status string
-	behindCount := len(migrator.Migrations) - int(migrationVersion)
-	if behindCount == 0 {
+	currentVersion := int(migrationVersion)
+	totalMigrations := len(migrator.Migrations)
+	switch {
+	case currentVersion < 0:
+		status = "version below zero"
+	case currentVersion > totalMigrations:
+		status = "version out of range"
+	case currentVersion == totalMigrations:
 		status = "up to date"
-	} else {
+	default:
 		status = "migration(s) pending"
 	}
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -484,6 +484,24 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (v int32, err error) {
 	return v, err
 }
 
+// SetVersion sets the current migration version without running any migrations.
+// This is useful for baselining an existing database when adopting tern.
+func (m *Migrator) SetVersion(ctx context.Context, version int32) (err error) {
+	err = acquireAdvisoryLock(ctx, m.conn)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		unlockErr := releaseAdvisoryLock(ctx, m.conn)
+		if err == nil && unlockErr != nil {
+			err = unlockErr
+		}
+	}()
+
+	_, err = m.conn.Exec(ctx, "update "+m.versionTable+" set version=$1", version)
+	return err
+}
+
 func (m *Migrator) ensureSchemaVersionTableExists(ctx context.Context) (err error) {
 	err = acquireAdvisoryLock(ctx, m.conn)
 	if err != nil {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -672,6 +672,34 @@ func TestAddPrimaryKeyToExistingVersionTable(t *testing.T) {
 	require.True(t, hasPK, "expected version table to have a primary key after NewMigrator")
 }
 
+func TestSetVersion(t *testing.T) {
+	conn := connectConn(t)
+	defer conn.Close(context.Background())
+
+	m := createEmptyMigrator(t, conn)
+	require.EqualValues(t, 0, currentVersion(t, conn))
+
+	// Set version forward
+	err := m.SetVersion(context.Background(), 5)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, currentVersion(t, conn))
+
+	// Set version backward
+	err = m.SetVersion(context.Background(), 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, currentVersion(t, conn))
+
+	// Set version to same value
+	err = m.SetVersion(context.Background(), 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, currentVersion(t, conn))
+
+	// Set version back to zero
+	err = m.SetVersion(context.Background(), 0)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, currentVersion(t, conn))
+}
+
 // // https://github.com/jackc/tern/issues/18
 func TestNotCreatingVersionTableIfAlreadyVisibleInSearchPath(t *testing.T) {
 	conn := connectConn(t)

--- a/tern_test.go
+++ b/tern_test.go
@@ -248,6 +248,52 @@ version:  1 of 2`
 	}
 }
 
+func TestOverrideVersion(t *testing.T) {
+	// Ensure database is in clean state
+	tern(t, "migrate", "-m", "testdata", "-c", "testdata/tern.conf", "-d", "0")
+	// Reset version on the way out. Must use override-version (not migrate -d 0)
+	// because override-version sets the version without creating tables, so a real
+	// down-migration would fail trying to drop tables that never existed.
+	defer tern(t, "override-version", "-c", "testdata/tern.conf", "0")
+
+	// Override the version without running any migrations
+	output := tern(t, "override-version", "-c", "testdata/tern.conf", "2")
+	if !strings.Contains(output, "version overridden: 0 → 2") {
+		t.Errorf("Expected output to contain `version overridden: 0 → 2`, but it didn't. Output:\n%s", output)
+	}
+
+	// The version should be updated
+	if currentVersion(t) != 2 {
+		t.Errorf("Expected current version to be 2, but it was %d", currentVersion(t))
+	}
+
+	// But the tables should NOT exist — that's the whole point of override-version
+	if tableExists(t, "t1") {
+		t.Error("Expected table t1 to not exist (override-version must not run migrations)")
+	}
+	if tableExists(t, "t2") {
+		t.Error("Expected table t2 to not exist (override-version must not run migrations)")
+	}
+
+	// Override backward
+	output = tern(t, "override-version", "-c", "testdata/tern.conf", "1")
+	if !strings.Contains(output, "version overridden: 2 → 1") {
+		t.Errorf("Expected output to contain `version overridden: 2 → 1`, but it didn't. Output:\n%s", output)
+	}
+	if currentVersion(t) != 1 {
+		t.Errorf("Expected current version to be 1, but it was %d", currentVersion(t))
+	}
+
+	// Override to the same version prints a distinct message
+	output = tern(t, "override-version", "-c", "testdata/tern.conf", "1")
+	if !strings.Contains(output, "version already at 1") {
+		t.Errorf("Expected output to contain `version already at 1`, but it didn't. Output:\n%s", output)
+	}
+	if currentVersion(t) != 1 {
+		t.Errorf("Expected current version to be 1, but it was %d", currentVersion(t))
+	}
+}
+
 func TestInstallCode(t *testing.T) {
 	tern(t, "code", "install", "-c", "testdata/tern.conf", "testdata/code")
 


### PR DESCRIPTION
Add `tern override-version VERSION` for baselining an existing database when adopting tern, as discussed in #129.

This introduces:

1. `tern override-version VERSION` sets the migration version in the schema_version table without running any migrations. Accompanied by a `Migrator.SetVersion(ctx, version)` library method.

2. Fix for `tern status` when the current version is out of range (e.g. after an override beyond the loaded migrations). Previously shown as "migration(s) pending", now shown as "version out of range" or "version below zero".

3. Hint in `tern migrate` when a down migration fails and points the user at `override-version` as a likely cause and recovery path.

Closes #129.