### PR TITLE
Print new migration filepath on success to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -477,6 +477,7 @@ func NewMigration(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	fmt.Fprintln(os.Stdout, mPath)
 
 	if cliOptions.editNewMigration {
 		editor := os.Getenv("EDITOR")


### PR DESCRIPTION
Outputs the file path to stdout for immediate visibility, akin to golang-migrate